### PR TITLE
Fix emacsclient emulated request payload to include SPC

### DIFF
--- a/scrim/Services/EmacsClient.swift
+++ b/scrim/Services/EmacsClient.swift
@@ -183,12 +183,12 @@ extension ScrimNetworking {
             var message: String?
             switch messageType {
             case .eval:
-                message = "-eval \(quote(payload))\n"
+                message = "-eval \(quote(payload)) \n"
             case .file:
-                message = "-nowait -file \(quote(payload))\n"
+                message = "-nowait -file \(quote(payload)) \n"
                 
             case .orgProtocol:
-                message = "-file \(quote(payload))\n"
+                message = "-file \(quote(payload)) \n"
             }
             
             if let message {


### PR DESCRIPTION
This change embeds a SPC character before the newline in a request payload made
to Emacs server.
